### PR TITLE
removed an echo ->apiCallUrl

### DIFF
--- a/Service/RestApi.php
+++ b/Service/RestApi.php
@@ -147,8 +147,6 @@ class RestApi
         $this->apiCallUrl = trim($this->getUrl(), '/') . '/' . ltrim($url, '/');
         $this->headers = $this->getDefaultHeaders();
 
-        echo $this->apiCallUrl;
-
         switch ($postType) {
             case 'GET':
                 $this->buildGetCall($handle, $dataArray);
@@ -361,5 +359,4 @@ class RestApi
     {
         return $this->password;
     }
-
 }


### PR DESCRIPTION
There is an echo $this->apiCallUrl that is shown everywhere.

I am guessing that this is not the right behavior, I removed this line. 

at line 150 of Service\RestApi.php. 
